### PR TITLE
Adding ability to disable disqus on a single post

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
                 {{ partial "share.html" . }}
             {{ end }}
 
-            {{ if .Site.Params.enableDisqus }}
+            {{ if and (.Site.Params.enableDisqus) (not .Params.disableDisqus) }}
                 {{ partial "disqus.html" . }}
             {{ end }}
 


### PR DESCRIPTION
With this you can add `disableDisqus = true` to a page to disable loading Disqus, even if it is enabled site wide. This is useful for pages that are not blog entries, but informational, like about pages. See #26 and #27, but it was removed for some reason in a later commit