### PR TITLE
Replace .Hugo.Generator with hugo.Generator

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,7 @@
 		{{ end }}
 		{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 		{{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
-		{{ .Hugo.Generator }}
+		{{ hugo.Generator }}
 		<title>{{ if .IsHome }}{{ .Title }}{{ else }}{{ .Title }} &middot; {{ .Site.Title }}{{ end }}</title>
 		<link rel="shortcut icon" href="{{ .Site.BaseURL }}images/favicon.ico">
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">


### PR DESCRIPTION
Page's .Hugo is deprecated in a future release
https://discourse.gohugo.io/t/pages-hugo-is-deprecated-as-of-0-55-0/17991