### PR TITLE
Add rel-me to social links

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -2,7 +2,7 @@
 {{ if eq .Site.Params.iconFont "font-awesome" }}
 	
 	{{ range $key, $val := .Site.Social }}
-    <a class="symbol" href="{{ $val }}">
+    <a class="symbol" rel="me" href="{{ $val }}">
         <i class="fa fa-{{ $key }}"></i>
     </a>
     {{ end }}
@@ -11,7 +11,7 @@
 	
 	{{ $iconStyle := .Site.Params.socialIconStyle }}
     {{ range $key, $val := .Site.Social }}
-    <a class="symbol" href="{{ $val }}">
+    <a class="symbol" rel="me" href="{{ $val }}">
         {{ $iconStyle }}{{ if eq $key "twitter" }}twitterbird{{ else }}{{ $key }}{{ end }}
     </a>
     {{ end }}


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.