### PR TITLE
Add overflow-x: auto to hightlight

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -102,6 +102,7 @@ h4:hover a {
 }
 .highlight pre {
   padding: 7px;
+  overflow-x: auto;
 }
 
 .highlight {


### PR DESCRIPTION
The currently problem is without `overflow-x: auto;` The code that exceeds the post width will not have the highlight background. Setting overflow-x will allow the code snippet to be properly rendered.