### PR TITLE
Remove Extra </div>

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -14,7 +14,6 @@
           <div>The content you're looking for doesn't seem to exist.</div>
       {{ end }}
     </div>
-  </div>
 
   {{ with .Site.Params.readMore }}
       <h2 class="read-more">{{ . }}</h2> 


### PR DESCRIPTION
The extra `div` tag will disrupt the 404 page layout.