### PR TITLE
Add addtional seetings in config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Take a look inside the [`exampleSite`](https://github.com/nodejh/hugo-theme-mini
 
 > ⚠️ You may need to delete the line: `themesDir: ../../` 
 
+After your site is read, add `env: production` in `params` in [`config.yaml`](https://github.com/nodejh/hugo-theme-mini/blob/master/exampleSite/config.yaml).
+
 ### Add Comments
 
 To enable comments, add following to your config file:


### PR DESCRIPTION
Without setting this option, Google would refuse indexing the web page because Google would complain `No: 'noindex' detected in 'robots' meta tag`