### PR TITLE
Seriously toggle off the partialCache !!!!!!

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
   <head>
     <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 
-    {{ partialCached "head.html" . }}
+    {{ partial "head.html" . }}
 
   </head>
 


### PR DESCRIPTION
Seriously toggle off the partialCache and it will save a world of trouble for you!!! I was browsing through the meta tag and notice all the descriptions are completely random and dead wrong. Every time I rerun `hugo server` it outputs something completely random. My twitter cards are fucked up as well. Using partialCache causes this problem. Please fix it...  Take a look at [https://nodejh.com/posts/%E4%BB%8E%E9%9B%B6%E7%BC%96%E5%86%99%E7%AC%AC%E4%B8%80%E4%B8%AA-flink-%E5%BA%94%E7%94%A8/](https://nodejh.com/posts/%E4%BB%8E%E9%9B%B6%E7%BC%96%E5%86%99%E7%AC%AC%E4%B8%80%E4%B8%AA-flink-%E5%BA%94%E7%94%A8/). You will notice the meta description doesn't match the actual post at all.