### PR TITLE
fix unwanted spaces in link rendering

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,13 +1,1 @@
-<a 
-    href="{{ .Destination | safeURL }}"
-    {{ with .Title}}
-      title="{{ . }}"
-    {{ end }}
-    
-    {{ if strings.HasPrefix .Destination "http" }} 
-      target="_blank" 
-      rel="noopener"
-    {{ end }}
->
-    {{ .Text | safeHTML }}
-</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}" {{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
the links currently rendered are huge in the html template, and they introduce unwanted whitespace if the link is enclosed in "non-link" characters ([this is an example - the "(" and ")" enclose the link and there should not be any whitespace between](https://www.google.com)). see also image below.

this PR makes link rendering much more compact in the resulting HTML, and fixes the whitespace issue.

<img width="137" alt="grafik" src="https://user-images.githubusercontent.com/5030694/129562774-be617a4a-52ae-45d0-ac34-0be9b1deda6c.png">
