### PR TITLE
Example site: correct rendering of subscript, superscript and other raw html markup

### DIFF
--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 /public
 /themes
 .DS_Store
+.hugo_build.lock

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -28,6 +28,10 @@ markup:
     endLevel: 3
     ordered: false
     startLevel: 2
+  # needed to render raw HTML (e.g. <sub>, <sup>, <kbd>, <mark>)
+  goldmark:
+    renderer:
+      unsafe: true
 
 # Social links in footer, support github,twitter,stackoverflow,facebook
 social:


### PR DESCRIPTION
**Demo site, [Markdown Syntax Guide](https://nodejh.com/hugo-theme-mini/posts/markdown-syntax-guide/):**

Last chapter `Other Elements — abbr, sub, sup, kbd, mark`

Terms like H<sub>2</sub>O are rendered incorrectly since by default, hugo's default renderer `goldmark` scrubs raw html tags for security reasons (see hugo's [documentation](https://gohugo.io/getting-started/configuration-markup#goldmark) on this topic). This PR corrects this incorrect rendering.