### PR TITLE
Don't prefix relURL arguments with /

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,7 +10,7 @@
   <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 {{ end }}
 
-<link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 
 {{ range .Site.Params.customCSS }}
   {{ if ( or ( hasPrefix . "http://" ) ( hasPrefix . "https://" ) ) }}
@@ -22,7 +22,7 @@
   {{ end }}
 {{ end }}
 
-<link rel="shortcut icon" href="{{ "/images/favicon.ico" | relURL }}" type="image/x-icon" />
+<link rel="shortcut icon" href="{{ "images/favicon.ico" | relURL }}" type="image/x-icon" />
 
 {{ if .Site.Params.enableGoogleAnalytics }} 
     {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,10 +1,10 @@
 <nav class="navigation">
 	{{ if not .IsHome }}
-		<a href="{{ "/" | relURL }}"> <span class="arrow">←</span>{{ with .Site.Params.home }}{{ . }}{{ else }}{{ i18n "home" }}{{ end }}</a>
+		<a href="{{ "" | relURL }}"> <span class="arrow">←</span>{{ with .Site.Params.home }}{{ . }}{{ else }}{{ i18n "home" }}{{ end }}</a>
 	{{ end }}
-	<a href="{{ "/posts" | relURL }}">{{ with .Site.Params.archive }}{{ . }}{{ else }}{{ i18n "archive" }}{{ end }}</a>
-	<a href="{{ "/tags" | relURL }}">{{ with .Site.Params.tags }}{{ . }}{{ else }}{{ i18n "tags" }}{{ end }}</a>
-	<a href="{{ "/about" | relURL }}">{{ with .Site.Params.about }}{{ . }}{{ else }}{{ i18n "about" }}{{ end }}</a>
+	<a href="{{ "posts" | relURL }}">{{ with .Site.Params.archive }}{{ . }}{{ else }}{{ i18n "archive" }}{{ end }}</a>
+	<a href="{{ "tags" | relURL }}">{{ with .Site.Params.tags }}{{ . }}{{ else }}{{ i18n "tags" }}{{ end }}</a>
+	<a href="{{ "about" | relURL }}">{{ with .Site.Params.about }}{{ . }}{{ else }}{{ i18n "about" }}{{ end }}</a>
 
 	{{ range $element := .Site.Params.Links }}
 		<a href="{{ $element.path }}">{{ $element.name }}</a>

--- a/layouts/partials/profile.html
+++ b/layouts/partials/profile.html
@@ -1,10 +1,10 @@
 <header class="profile">
     {{ if .Site.Params.avatarLink }}
         <a href="{{ .Site.Params.avatarLink }}">
-          <img class="avatar" alt="avatar" src="{{ "/images/avatar.png" | relURL }}" />
+          <img class="avatar" alt="avatar" src="{{ "images/avatar.png" | relURL }}" />
         </a>
     {{ else }}
-        <img class="avatar" alt="avatar" src="{{ "/images/avatar.png" | relURL }}" />
+        <img class="avatar" alt="avatar" src="{{ "images/avatar.png" | relURL }}" />
     {{ end }}
 
     <h1>{{ .Site.Title }}</h1>


### PR DESCRIPTION
Hugo 0.101 contains a fix for https://github.com/gohugoio/hugo/issues/9994, which makes relURL starting with / absolute to the baseURL. For example, if your baseURL is www.example.com/someSubdirectory, the css link would be /css/style.css in index.html despite index.html being in someSubdirectory.