### PR TITLE
Support GA4 tag

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,7 +25,7 @@
 <link rel="shortcut icon" href="{{ "/images/favicon.ico" | relURL }}" type="image/x-icon" />
 
 {{ if .Site.Params.enableGoogleAnalytics }} 
-    {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 
 {{ if or .Params.math .Site.Params.math }}


### PR DESCRIPTION
Added support for Google Analytics 4 tags.

https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics.html

https://gohugo.io/templates/internal/#use-the-google-analytics-template