### PR TITLE
Support dark mode in Firefox

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,6 +2,12 @@ html[theme='dark-mode'] {
   filter: invert(1) hue-rotate(180deg);
 }
 
+@media (prefers-color-scheme: dark) {
+  html {
+    filter: invert(1) hue-rotate(180deg);
+  }
+}
+
 body {
   line-height: 1;
   font: normal 15px/1.5em 'Helvetica Neue', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Seems that the default dark mode style filter does not apply, at least, when using Firefox browser.

This pull request fixes dark mode support in Firefox.

See https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme for more information.